### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Unofficial python api of [The &rsquo;Zine](http://thezine.biz)
 
-| Build Status | Version |Test Coverage | Downloads |
-| ------------ | ------- | ------------ | --------- |
-| [![Build Status](https://travis-ci.org/voidabhi/TheZineAPI.svg)](https://travis-ci.org/voidabhi/TheZineAPI)|[![Latest Version](https://img.shields.io/pypi/v/TheZine.svg | [![Coverage Status](https://img.shields.io/coveralls/voidabhi/TheZineAPI.svg)](https://coveralls.io/r/voidabhi/TheZineAPI?branch=master)|[![Downloads](https://img.shields.io/pypi/dm/TheZine.svg
+| Build Status | Version |Test Coverage |
+| ------------ | ------- | ------------ |
+| [![Build Status](https://travis-ci.org/voidabhi/TheZineAPI.svg)](https://travis-ci.org/voidabhi/TheZineAPI)|[![Latest Version](https://img.shields.io/pypi/v/TheZine.svg)](https://pypi.python.org/pypi/TheZine/) | [![Coverage Status](https://img.shields.io/coveralls/voidabhi/TheZineAPI.svg)](https://coveralls.io/r/voidabhi/TheZineAPI?branch=master)|
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unofficial python api of [The &rsquo;Zine](http://thezine.biz)
 
 | Build Status | Version |Test Coverage | Downloads |
 | ------------ | ------- | ------------ | --------- |
-| [![Build Status](https://travis-ci.org/voidabhi/TheZineAPI.svg)](https://travis-ci.org/voidabhi/TheZineAPI)|[![Latest Version](https://pypip.in/v/TheZine/badge.png)](https://pypi.python.org/pypi/TheZine/) | [![Coverage Status](https://img.shields.io/coveralls/voidabhi/TheZineAPI.svg)](https://coveralls.io/r/voidabhi/TheZineAPI?branch=master)|[![Downloads](https://pypip.in/d/TheZine/badge.png)](https://pypi.python.org/pypi/TheZine/)
+| [![Build Status](https://travis-ci.org/voidabhi/TheZineAPI.svg)](https://travis-ci.org/voidabhi/TheZineAPI)|[![Latest Version](https://img.shields.io/pypi/v/TheZine.svg | [![Coverage Status](https://img.shields.io/coveralls/voidabhi/TheZineAPI.svg)](https://coveralls.io/r/voidabhi/TheZineAPI?branch=master)|[![Downloads](https://img.shields.io/pypi/dm/TheZine.svg
 
 ### Installation
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20thezine))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `thezine`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.